### PR TITLE
fix load_current_resource for Chef 13

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -145,7 +145,7 @@ def get_current_state(service_name)
 end
 
 def load_current_resource
-  @current_resource = Chef::Resource::SupervisorService.new(@new_resource.name)
+  @current_resource = Chef::ResourceResolver.resolve(:supervisor_service).new(@new_resource.name)
   @current_resource.state = get_current_state(@new_resource.name)
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,7 @@
 # Install
 python_runtime 'supervisor' do
   version '2'
+  provider :system
 end
 
 # foodcritic FC023: we prefer not having the resource on non-smartos
@@ -89,7 +90,7 @@ when "amazon", "centos", "debian", "fedora", "redhat", "ubuntu", "raspbian"
     variables({
       # TODO: use this variable in the debian platform-family template
       # instead of altering the PATH and calling "which supervisord".
-      :supervisord => "/usr/local/bin/supervisord"
+      :supervisord => "/usr/bin/supervisord"
     })
   end
 


### PR DESCRIPTION
Drop-in fix for Chef 13 difference https://blog.chef.io/2015/06/24/chef-client-12-4-0-released/ (near bottom of page)